### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # `docker.io/paketobuildpacks/elastic-apm`
-The Paketo Elastic APM Buildpack is a Cloud Native Buildpack that contributes the [Elastic APM][e] Agent and configures it to connect to the service.
+The Paketo Buildpack for Elastic APM is a Cloud Native Buildpack that contributes the [Elastic APM][e] Agent and configures it to connect to the service.
 
 [e]: https://www.elastic.co/solutions/apm
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/elastic-apm"
   id = "paketo-buildpacks/elastic-apm"
   keywords = ["elastic-apm", "agent", "apm", "java", "node.js"]
-  name = "Paketo Elastic APM Buildpack"
+  name = "Paketo Buildpack for Elastic APM"
   sbom-formats = ["application/vnd.syft+json", "application/vnd.cyclonedx+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Elastic APM Buildpack' to 'Paketo Buildpack for Elastic APM'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
