### PR TITLE
Fix Java Agent Update Checks

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -26,6 +26,7 @@ dependencies:
     uri:         https://repo1.maven.org/maven2
     group_id:    co.elastic.apm
     artifact_id: elastic-apm-agent
+    source_classifier: sources
 - id:   elastic-apm-nodejs
   uses: docker://ghcr.io/paketo-buildpacks/actions/npm-dependency:main
   with:

--- a/.github/workflows/pb-update-elastic-apm-java.yml
+++ b/.github/workflows/pb-update-elastic-apm-java.yml
@@ -46,6 +46,7 @@ jobs:
               with:
                 artifact_id: elastic-apm-agent
                 group_id: co.elastic.apm
+                source_classifier: sources
                 uri: https://repo1.maven.org/maven2
             - name: Update Buildpack Dependency
               id: buildpack


### PR DESCRIPTION
## Summary

Java agent updater is broken.

## Use Cases

The update checker was failing because the format of the source URL was wrong. This change adds a `source_classifier` so that we can locate the correct URL for the source download.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
